### PR TITLE
ril-caf: Fix crash when enabling RILC_LOG

### DIFF
--- a/libril/ril.cpp
+++ b/libril/ril.cpp
@@ -3832,7 +3832,7 @@ static int responseRadioCapability(Parcel &p, void *response, size_t responselen
 
     startResponse;
     appendPrintBuf("%s[version=%d,session=%d,phase=%d,\
-            rat=%s,logicalModemUuid=%s,status=%d]",
+            rat=%d,logicalModemUuid=%s,status=%d]",
             printBuf,
             p_cur->version,
             p_cur->session,


### PR DESCRIPTION
Change-Id: I06ebba728e009a29958dee0bc5d4a652c3ad31db